### PR TITLE
Changed to off rule: react/react-in-jsx-scope

### DIFF
--- a/react/index.js
+++ b/react/index.js
@@ -161,7 +161,7 @@ module.exports = {
     "react/prefer-stateless-function": "error",
     "react/prop-types": [2, { ignore: ["style", "children", "dispatch"] }],
     "react/require-default-props": "off",
-    "react/react-in-jsx-scope": "error",
+    "react/react-in-jsx-scope": "off",
     "react/require-render-return": "error",
     "react/self-closing-comp": "error",
     "react/sort-prop-types": [

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolox/eslint-config-react",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Wolox's ESLint configuration for React projects ",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## Summary

* Changed to `off` the rule react/react-in-jsx-scope
* Moved major to `2.0.0` due to `MAJOR version when you make incompatible API changes`. If im wrong correct me
