### PR TITLE
[eslint-config-typescript] Update peer dependencies - rules

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -14,7 +14,6 @@ Also, this configuration relies on some peer dependencies you must add in your p
 - [eslint-plugin-babel](https://github.com/babel/eslint-plugin-babel)
 - [eslint-import-resolver-typescript](https://www.npmjs.com/package/eslint-import-resolver-typescript)
 - [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser)
-- [eslint-plugin-react-hooks](https://github.com/facebook/react)
 - [@typescript-eslint/eslint-plugin](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin)
 
 Make sure you check that the version you install in your project matches the one in this configuration's package.json

--- a/typescript/index.js
+++ b/typescript/index.js
@@ -19,10 +19,17 @@ module.exports = {
     'no-use-before-define': 'off',
     'no-shadow': 'off',
     'no-undef': 'off',
+    
+    // note you must disable the base rule as it can report incorrect errors
     'no-magic-numbers': 'off',
+    "keyword-spacing": "off",
+    "brace-style": "off",
+
     '@typescript-eslint/adjacent-overload-signatures': 'error',
+    "@typescript-eslint/array-type": ["error", { "default": "array", "readonly": "array" }],
     '@typescript-eslint/ban-ts-comment': 'error',
     '@typescript-eslint/ban-types': 'error',
+    "@typescript-eslint/brace-style": ["error"],
     '@typescript-eslint/naming-convention': [
       'error',
       {
@@ -67,9 +74,11 @@ module.exports = {
     '@typescript-eslint/prefer-namespace-keyword': 'error',
     '@typescript-eslint/triple-slash-reference': 'error',
     '@typescript-eslint/type-annotation-spacing': 'error',
+    "@typescript-eslint/keyword-spacing": ["error"],
     '@typescript-eslint/no-shadow': 'error',
     '@typescript-eslint/no-magic-numbers': [
       'error', { ignore: [0, 1, -1, 2], 'ignoreEnums': true }
-    ]
+    ],
+    
   },
 };

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -17,13 +17,12 @@
   "bugs": {
     "url": "https://github.com/Wolox/eslint-config/issues"
   },
-  "homepage": "https://github.com/Wolox/eslint-config/typescript#readme",
+  "homepage": "https://github.com/Wolox/eslint-config/tree/main/typescript",
   "peerDependencies": {
     "eslint": "^8.4.1",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-babel": "5.3.1",
     "eslint-import-resolver-typescript": "^2.5.0",
-    "eslint-config-prettier": "^8.3.0",
     "@typescript-eslint/parser": "5.7.0",
     "@typescript-eslint/eslint-plugin": "5.7.0"
   }

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -23,7 +23,7 @@
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-babel": "5.3.1",
     "eslint-import-resolver-typescript": "^2.5.0",
-    "@typescript-eslint/parser": "5.7.0",
-    "@typescript-eslint/eslint-plugin": "5.7.0"
+    "@typescript-eslint/parser": "5.3.0",
+    "@typescript-eslint/eslint-plugin": "5.3.0"
   }
 }

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolox/eslint-config-typescript",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Wolox's ESLint typescript configuration",
   "main": "index.js",
   "repository": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -23,6 +23,7 @@
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-babel": "5.3.1",
     "eslint-import-resolver-typescript": "^2.3.0",
+    "eslint-config-prettier": "^8.3.0",
     "@typescript-eslint/parser": "4.14.2",
     "@typescript-eslint/eslint-plugin": "4.14.2"
   }

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolox/eslint-config-typescript",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Wolox's ESLint typescript configuration",
   "main": "index.js",
   "repository": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -19,12 +19,12 @@
   },
   "homepage": "https://github.com/Wolox/eslint-config/typescript#readme",
   "peerDependencies": {
-    "eslint": "7.19.0",
-    "eslint-plugin-import": "2.22.1",
+    "eslint": "^8.4.1",
+    "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-babel": "5.3.1",
-    "eslint-import-resolver-typescript": "^2.3.0",
+    "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-config-prettier": "^8.3.0",
-    "@typescript-eslint/parser": "4.14.2",
-    "@typescript-eslint/eslint-plugin": "4.14.2"
+    "@typescript-eslint/parser": "5.7.0",
+    "@typescript-eslint/eslint-plugin": "5.7.0"
   }
 }


### PR DESCRIPTION
## Summary

Peer dependencies versions are upgraded d2f6d74 fb79928
Add new typescript rules 10ecb91

## Known Issues

- Don't need `eslint-plugin-react-hooks` as peer dependencies.
- Peer dependencies versions are old.
