### PR TITLE
Update dependencies 202301

### DIFF
--- a/javascript/CHANGELOG.md
+++ b/javascript/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.0.0
+* Updated following packages
+  * eslint
+  * prettier
+  * prettier-eslint
+  * eslint-plugin-prettier
+
 ## 1.0.0
 
 * Changelog added.

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -32,6 +32,7 @@ module.exports = {
     "import/no-useless-path-segments": "error",
 
     // Eslint Possible Errors - https://eslint.org/docs/rules/#possible-errors
+    "array-callback-return": "error",
     "for-direction": "error",
     "getter-return": "error",
     "no-async-promise-executor": "error",

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolox/eslint-config",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Base JS ESLint configuration used by Wolox",
   "main": "index.js",
   "repository": {
@@ -12,10 +12,10 @@
     "url": "https://github.com/Wolox/eslint-config/issues"
   },
   "peerDependencies": {
-    "eslint": "7.x",
-    "prettier": "2.x",
-    "prettier-eslint": "12.x",
-    "eslint-plugin-prettier": "3.x",
+    "eslint": "^8.x",
+    "prettier": "^2.x",
+    "prettier-eslint": "15.x",
+    "eslint-plugin-prettier": "4.x",
     "eslint-plugin-import": "2.x"
   },
   "homepage": "https://github.com/Wolox/eslint-config/javascript#readme"

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -12,11 +12,11 @@
     "url": "https://github.com/Wolox/eslint-config/issues"
   },
   "peerDependencies": {
-    "eslint": "^8.x",
-    "prettier": "^2.x",
-    "prettier-eslint": "15.x",
-    "eslint-plugin-prettier": "4.x",
-    "eslint-plugin-import": "2.x"
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-prettier": "^4.2.1",
+    "eslint": "^8.30.0",
+    "prettier-eslint": "^15.0.1",
+    "prettier": "^2.8.1"
   },
   "homepage": "https://github.com/Wolox/eslint-config/javascript#readme"
 }

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -12,11 +12,11 @@
     "url": "https://github.com/Wolox/eslint-config/issues"
   },
   "peerDependencies": {
-    "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-prettier": "^4.2.1",
-    "eslint": "^8.30.0",
-    "prettier-eslint": "^15.0.1",
-    "prettier": "^2.8.1"
+    "eslint-plugin-import": "2.27.5",
+    "eslint-plugin-prettier": "4.2.1",
+    "eslint": "8.34.0",
+    "prettier-eslint": "15.0.1",
+    "prettier": "2.8.4"
   },
   "homepage": "https://github.com/Wolox/eslint-config/javascript#readme"
 }

--- a/node/package.json
+++ b/node/package.json
@@ -19,10 +19,10 @@
   },
   "homepage": "https://github.com/Wolox/eslint-config-wolox/node#readme",
   "peerDependencies": {
-    "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-prettier": "^4.2.1",
-    "eslint": "^8.30.0",
-    "prettier-eslint": "^15.0.1",
-    "prettier": "^2.8.1"
+    "eslint-plugin-import": "2.27.5",
+    "eslint-plugin-prettier": "4.2.1",
+    "eslint": "8.34.0",
+    "prettier-eslint": "15.0.1",
+    "prettier": "2.8.4"
   }
 }

--- a/node/package.json
+++ b/node/package.json
@@ -19,11 +19,10 @@
   },
   "homepage": "https://github.com/Wolox/eslint-config-wolox/node#readme",
   "peerDependencies": {
-    "eslint": "^8.x",
-    "eslint-config-wolox": "4.x",
-    "prettier": "^2.x",
-    "prettier-eslint": "15.x",
-    "eslint-plugin-prettier": "4.x",
-    "eslint-plugin-import": "2.x"
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-prettier": "^4.2.1",
+    "eslint": "^8.30.0",
+    "prettier-eslint": "^15.0.1",
+    "prettier": "^2.8.1"
   }
 }

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolox/eslint-config-node",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Wolox's ESLint configuration for NodeJS projects",
   "main": "index.js",
   "repository": {
@@ -19,11 +19,11 @@
   },
   "homepage": "https://github.com/Wolox/eslint-config-wolox/node#readme",
   "peerDependencies": {
-    "eslint": "7.x",
+    "eslint": "^8.x",
     "eslint-config-wolox": "4.x",
-    "prettier": "2.x",
-    "prettier-eslint": "12.x",
-    "eslint-plugin-prettier": "3.x",
+    "prettier": "^2.x",
+    "prettier-eslint": "15.x",
+    "eslint-plugin-prettier": "4.x",
     "eslint-plugin-import": "2.x"
   }
 }

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolox/eslint-config-react-native",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Wolox's ESLint configuration for React Native projects",
   "main": "index.js",
   "repository": {
@@ -19,15 +19,15 @@
   },
   "homepage": "https://github.com/Wolox/eslint-config/react-native#readme",
   "peerDependencies": {
-    "@react-native-community/eslint-config": "2.0.0",
-    "@typescript-eslint/parser": "^4.14.2",
-    "eslint": "^7.19.0",
+    "@react-native-community/eslint-config": "3.2.0",
+    "@typescript-eslint/eslint-plugin": "5.51.0",
+    "@typescript-eslint/parser": "5.51.0",
     "@wolox/eslint-config": "^1.0.0",
-    "eslint-plugin-prettier": "^3.3.1",
-    "eslint-plugin-react": "^7.22.0",
-    "prettier": "^2.2.1",
-    "@typescript-eslint/eslint-plugin": "^4.14.2",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-react-native": "^3.10.0"
+    "eslint-plugin-import": "2.27.5",
+    "eslint-plugin-prettier": "4.2.1",
+    "eslint-plugin-react-native": "4.0.0",
+    "eslint-plugin-react": "7.32.0",
+    "eslint": "^8.30.0",
+    "prettier": "^2.8.1"
   }
 }

--- a/react-native/package.json
+++ b/react-native/package.json
@@ -26,8 +26,8 @@
     "eslint-plugin-import": "2.27.5",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react-native": "4.0.0",
-    "eslint-plugin-react": "7.32.0",
-    "eslint": "^8.30.0",
-    "prettier": "^2.8.1"
+    "eslint-plugin-react": "7.32.2",
+    "eslint": "8.34.0",
+    "prettier": "2.8.4"
   }
 }

--- a/react/index.js
+++ b/react/index.js
@@ -127,7 +127,7 @@ module.exports = {
     "react/jsx-no-target-blank": "error",
     "react/jsx-pascal-case": "error",
     "react/jsx-props-no-multi-spaces": "error",
-    "react/jsx-sort-default-props": "error",
+    "react/sort-default-props": "error",
     "react/jsx-tag-spacing": ["error", { beforeClosing: "never" }],
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolox/eslint-config-react",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Wolox's ESLint configuration for React projects ",
   "main": "index.js",
   "repository": {
@@ -19,14 +19,14 @@
   },
   "homepage": "https://github.com/Wolox/eslint-config/react#readme",
   "peerDependencies": {
-    "eslint": "7.19.0",
-    "eslint-plugin-import": "2.22.1",
-    "eslint-plugin-jsx-a11y": "6.4.1",
-    "eslint-plugin-react": "7.22.0",
+    "eslint": "^8.30.0",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jsx-a11y": "6.6.1",
+    "eslint-plugin-react": "7.31.11",
     "eslint-plugin-babel": "5.3.1",
-    "prettier": "2.2.1",
-    "eslint-plugin-prettier": "3.3.1",
-    "eslint-plugin-react-hooks": "4.2.0",
-    "eslint-plugin-testing-library": "3.10.1"
+    "prettier": "2.8.1",
+    "eslint-plugin-prettier": "4.2.1",
+    "eslint-plugin-react-hooks": "4.6.0",
+    "eslint-plugin-testing-library": "5.9.1"
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -19,14 +19,14 @@
   },
   "homepage": "https://github.com/Wolox/eslint-config/react#readme",
   "peerDependencies": {
-    "eslint": "^8.30.0",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jsx-a11y": "6.6.1",
-    "eslint-plugin-react": "7.31.11",
     "eslint-plugin-babel": "5.3.1",
-    "prettier": "2.8.1",
+    "eslint-plugin-import": "2.27.5",
+    "eslint-plugin-jsx-a11y": "6.7.1",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-react-hooks": "4.6.0",
-    "eslint-plugin-testing-library": "5.9.1"
+    "eslint-plugin-react": "7.32.2",
+    "eslint-plugin-testing-library": "5.10.1",
+    "eslint": "^8.30.0",
+    "prettier": "^2.8.1"
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -26,7 +26,7 @@
     "eslint-plugin-react-hooks": "4.6.0",
     "eslint-plugin-react": "7.32.2",
     "eslint-plugin-testing-library": "5.10.1",
-    "eslint": "^8.30.0",
-    "prettier": "^2.8.1"
+    "eslint": "8.34.0",
+    "prettier": "2.8.4"
   }
 }

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -19,11 +19,11 @@
   },
   "homepage": "https://github.com/Wolox/eslint-config/tree/main/typescript",
   "peerDependencies": {
-    "eslint": "^8.30.0",
-    "eslint-plugin-import": "^2.26.0",
+    "@typescript-eslint/eslint-plugin": "5.51.0",
+    "@typescript-eslint/parser": "5.51.0",
+    "eslint-import-resolver-typescript": "3.5.3",
     "eslint-plugin-babel": "5.3.1",
-    "eslint-import-resolver-typescript": "^3.5.2",
-    "@typescript-eslint/parser": "5.47.0",
-    "@typescript-eslint/eslint-plugin": "5.47.0"
+    "eslint-plugin-import": "2.27.5",
+    "eslint": "^8.30.0"
   }
 }

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -24,6 +24,6 @@
     "eslint-import-resolver-typescript": "3.5.3",
     "eslint-plugin-babel": "5.3.1",
     "eslint-plugin-import": "2.27.5",
-    "eslint": "^8.30.0"
+    "eslint": "8.34.0"
   }
 }

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolox/eslint-config-typescript",
-  "version": "2.0.0",
+  "version": "4.0.0",
   "description": "Wolox's ESLint typescript configuration",
   "main": "index.js",
   "repository": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolox/eslint-config-typescript",
-  "version": "3.0.0",
+  "version": "2.0.0",
   "description": "Wolox's ESLint typescript configuration",
   "main": "index.js",
   "repository": {
@@ -19,11 +19,11 @@
   },
   "homepage": "https://github.com/Wolox/eslint-config/tree/main/typescript",
   "peerDependencies": {
-    "eslint": "^8.4.1",
-    "eslint-plugin-import": "^2.25.3",
+    "eslint": "^8.30.0",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-babel": "5.3.1",
-    "eslint-import-resolver-typescript": "^2.5.0",
-    "@typescript-eslint/parser": "5.3.0",
-    "@typescript-eslint/eslint-plugin": "5.3.0"
+    "eslint-import-resolver-typescript": "^3.5.2",
+    "@typescript-eslint/parser": "5.47.0",
+    "@typescript-eslint/eslint-plugin": "5.47.0"
   }
 }

--- a/vue/index.js
+++ b/vue/index.js
@@ -1,7 +1,8 @@
 "use strict";
 
 module.exports = {
-  plugins: ["vue", "prettier"],
+  extends: ["plugin:vue/vue3-recommended"],
+  plugins: ["prettier"],
   parser: "vue-eslint-parser",
   rules: {
     // Eslint Stylistic Issues - https://eslint.org/docs/rules/#stylistic-issues

--- a/vue/package.json
+++ b/vue/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/Wolox/eslint-config#readme",
   "peerDependencies": {
-    "eslint-plugin-prettier": "3.3.1",
+    "eslint-plugin-prettier": "4.2.1",
     "eslint-config-vue": "7.5.0",
-    "eslint": "7.19.0"
+    "eslint": "^8.30.0"
   }
 }

--- a/vue/package.json
+++ b/vue/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-vue": "9.9.0",
-    "eslint": "^8.30.0",
+    "eslint": "8.34.0",
     "vue-eslint-parser": "9.1.0"
   }
 }

--- a/vue/package.json
+++ b/vue/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/Wolox/eslint-config#readme",
   "peerDependencies": {
     "eslint-plugin-prettier": "4.2.1",
-    "eslint-config-vue": "7.5.0",
-    "eslint": "^8.30.0"
+    "eslint-plugin-vue": "9.9.0",
+    "eslint": "^8.30.0",
+    "vue-eslint-parser": "9.1.0"
   }
 }

--- a/vue/package.json
+++ b/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wolox/eslint-config-vue",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "ESLint configuration used at wolox for Vue projects.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- **General** (applies to every config)
  - Upgraded "eslint" to `8.34.0`
  - Upgraded "prettier" to `2.8.4`
- **Javascript** (`1.0.0` => `2.0.0`)
- **Node** (`1.0.0` => `2.0.0`)
- **React** (`2.0.0` => `3.0.0`)
  - Replaced deprecated rule "react/jsx-sort-default-props" for "react/sort-default-props" 
- **React-Native** (`1.0.0` => `2.0.0`)
- **Typescript** (`3.0.0` => `4.0.0`)
- **Vue** (`1.0.0` => `2.0.0`)
  - Added "eslint-plugin-vue": `"9.9.0"`
  - Added "vue-eslint-parser": `"9.1.0"`
